### PR TITLE
Work around Fish 3.x default bind

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -4,10 +4,22 @@ set -q sudope_sequence
 
 # if sudope is already bound to some sequence, leave it
 if not bind | string match -rq '[[:space:]]sudope$'
-  # not bound but sequence already taken?
-  if bind $sudope_sequence >/dev/null 2>/dev/null
-    echo "sudope: The requested sequence is already in use:" (bind $sudope_sequence | cut -d' ' -f2-)
-  else
-    bind $sudope_sequence sudope
+  switch $FISH_VERSION
+    # in 3.x, fish added a default binding for a more naive version of sudope,
+    # and we want to use ours. so we'll use the 3.x+ --user flag to override the preset
+    case '3.*'
+      # not bound but sequence already taken?
+      if bind --user $sudope_sequence >/dev/null 2>/dev/null
+        echo "sudope: The requested sequence is already in use:" (bind --user $sudope_sequence | cut -d' ' -f2-)
+      else
+        bind --user $sudope_sequence sudope
+      end
+    case '*'
+      # not bound but sequence already taken?
+      if bind $sudope_sequence >/dev/null 2>/dev/null
+        echo "sudope: The requested sequence is already in use:" (bind $sudope_sequence | cut -d' ' -f2-)
+      else
+        bind $sudope_sequence sudope
+    end
   end
 end


### PR DESCRIPTION
Fish 3.x added a default sudope-like key binding. Use bind’s 3.x+ `--user` flag to override the preset.

Fixes #12