### PR TITLE
Update key binding logic and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### About
 
-A Fish port of oh-my-zsh's [sudo plugin]
+A fish shell port of oh-my-zsh's [sudo plugin]
 
 ### Install
 
@@ -13,13 +13,48 @@ omf install sudope
 
 ### Usage
 
-Press `Alt`+`s` to activate it.
-It will add `sudo ` to the beginning of the line if missing, remove it if it is present while preserving the cursor position.
+Fish 2.3 and later: Press <kbd>Esc</kbd>+<kbd>Esc</kbd> or <kbd>Alt</kbd>+<kbd>Esc</kbd> to activate.
+(See the "Escape in Fish" appendix if you're having trouble activating sudope)
+
+Fish 2.2 and earlier: Press <kbd>Ctrl</kbd>+<kbd>s</kbd> to activate.
+(See Customization below if you want to change the binding.)
+
+It will add `sudo ` to the beginning of the line if missing, or remove it if it is present - while preserving the cursor position.
 If the current line is empty, it will do the same thing to the most recent history item.
+
+### Customization
+
+The default binding sequence can be overriden by setting `sudope_sequence` to the desired sequence.
+
+For example, to set the sequence to <kbd>Alt</kbd>+<kbd>u</kbd> you can add:
+```fish
+set -gx sudope_sequence \eu
+```
+To `~/.config/omf/init.fish`.
+
+**Escape in Fish**
+
+<kbd>Esc</kbd> is treated specially in fish:
+
+> The escape key can be used standalone, for example, to switch from insertion mode to normal mode when using Vi keybindings.
+> Escape can also be used as a "meta" key, to indicate the start of an escape sequence, like for function or arrow keys. Custom bindings can also be defined that begin with an escape character.
+>
+> Holding alt and something else also typically sends escape, for example holding alt+a will send an escape character and then an "a".
+>
+> fish waits for a period after receiving the escape character, to determine whether it is standalone or part of an escape sequence. While waiting, additional key presses make the escape key behave as a meta key.
+> If no other key presses come in, it is handled as a standalone escape. The waiting period is set to 30 milliseconds (0.03 seconds).
+> It can be configured by setting the `fish_escape_delay_ms` variable to a value between 10 and 5000 ms.
+> This can be a universal variable that you set once from an interactive session.
+>
+> Note: fish 2.2.0 and earlier used a default of 10 milliseconds, and provided no way to configure it. That effectively made it impossible to use escape as a meta key.
+
+(from https://fishshell.com/docs/3.1/cmds/bind.html#special-case-the-escape-character)
+
+In other words, using <kbd>Esc</kbd>+<kbd>Esc</kbd> is possible with fish 2.3+, but you might need to tweak `fish_escape_delay_ms` to more than 30ms if you're using fish 3.1+ and having trouble activating sudope reliably.
 
 #### License
 
-2015-2017 [ISC] @ [Itzik Ephraim]
+2015-2020 [ISC] @ [Itzik Ephraim]
 Commits e45d168 and 0928ab2: 2017 [ISC] @ [Chloe Kudryavtsev]
 
 [sudo plugin]: https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/sudo

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,25 +1,38 @@
-# default key sequence: Alt+s
+# default key sequence:
 set -q sudope_sequence
-  or set -l sudope_sequence \es
-
-# if sudope is already bound to some sequence, leave it
-if not bind | string match -rq '[[:space:]]sudope$'
-  switch $FISH_VERSION
-    # in 3.x, fish added a default binding for a more naive version of sudope,
-    # and we want to use ours. so we'll use the 3.x+ --user flag to override the preset
-    case '3.*'
-      # not bound but sequence already taken?
-      if bind --user $sudope_sequence >/dev/null 2>/dev/null
-        echo "sudope: The requested sequence is already in use:" (bind --user $sudope_sequence | cut -d' ' -f2-)
-      else
-        bind --user $sudope_sequence sudope
-      end
+  or switch $FISH_VERSION
+    case '2.0' '2.0.*' '2.1' '2.1.*' '2.2' '2.2.*'
+      # use Ctrl+s for fish 2.2 and earlier, as Esc is not usable as a meta key.
+      set sudope_sequence \cs
     case '*'
-      # not bound but sequence already taken?
-      if bind $sudope_sequence >/dev/null 2>/dev/null
-        echo "sudope: The requested sequence is already in use:" (bind $sudope_sequence | cut -d' ' -f2-)
-      else
-        bind $sudope_sequence sudope
-    end
+      # use Esc+Esc for fish 2.3+
+      set sudope_sequence \e\e
+  end
+
+function __sudope_bind -a sequence # modifiers..
+  set -l modifiers $argv[2..-1]
+
+  set -l current_binding (bind $modifiers $sequence 2>/dev/null | cut -d' ' -f2-)
+  if test -n "$current_binding"
+    echo "sudope: The sequence `$sequence` is already bound to: `$current_binding` (`$modifiers`)"
+  else
+    bind $modifiers -- $sequence sudope
   end
 end
+
+# if sudope is already bound to some sequence, leave it
+if bind | string match -rq '[[:space:]]sudope$'
+  exit
+end
+
+set -l -- bind_modifiers '--mode' "$fish_bind_mode"
+switch $FISH_VERSION
+  case '2.*'
+    # no change
+  case '*'
+    # in 3.x, fish added a default binding for a more naive version of sudope,
+    # and we want to use ours. so we'll use the 3.x+ `--user` flag to override the preset.
+    set -- bind_modifiers $bind_modifiers '--user'
+end
+
+__sudope_bind $sudope_sequence $bind_modifiers


### PR DESCRIPTION
1. Set the default binding to Esc+Esc for fish 2.3+, and revert to Ctrl+s for fish 2.2 and earlier. (addresses #11 & #10)
2. While binding, use the current mode, so that the binding will apply in insert mode as well. (addresses #7)
3. Update the README with information on customization and Esc behavior in fish.