### PR TITLE
Custom Super User Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ If the current line is empty, it will do the same thing to the most recent histo
 
 The default binding sequence can be overriden by setting `sudope_sequence` to the desired sequence.
 
-The default super user command "sudo" can be overriden by setting `su_command` to the desired command.
+The default super user command "sudo" can be overriden by setting `sudope_command` to the desired command.
 
 For example, to set the sequence to <kbd>Alt</kbd>+<kbd>u</kbd> and the super user command to "doas" you can add:
 ```fish
 set -gx sudope_sequence \eu
-set -gx su_command 'doas'
+set -gx sudope_command 'doas'
 ```
 To `~/.config/omf/init.fish`.
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ If the current line is empty, it will do the same thing to the most recent histo
 
 The default binding sequence can be overriden by setting `sudope_sequence` to the desired sequence.
 
-For example, to set the sequence to <kbd>Alt</kbd>+<kbd>u</kbd> you can add:
+The default super user command "sudo" can be overriden by setting `su_command` to the desired command.
+
+For example, to set the sequence to <kbd>Alt</kbd>+<kbd>u</kbd> and the super user command to "doas" you can add:
 ```fish
 set -gx sudope_sequence \eu
+set -gx su_command 'doas'
 ```
 To `~/.config/omf/init.fish`.
 

--- a/functions/sudope.fish
+++ b/functions/sudope.fish
@@ -5,12 +5,12 @@ function sudope -d "Quickly toggle super user command prefix"
   set -l cursor_position (commandline -C)
 
   # If no custom super user command defaults to sudo
-  if test -z "$su_command"
-    set su_command 'sudo'
+  if test -z "$sudope_command"
+    set sudope_command 'sudo'
   end
 
   # Save su command length
-  set -l su_command_length (string length -- "$su_command")
+  set -l sudope_command_length (string length -- "$sudope_command")
 
   # If the command line is empty, pull the last command from history.
   if test -z "$command_buffer"
@@ -18,7 +18,7 @@ function sudope -d "Quickly toggle super user command prefix"
   end
 
   # Parse the command line (first line only).
-  set -l command_parts (string match -ir "^(\s*)($su_command(\s+|\$))?(.*)" $command_buffer[1])
+  set -l command_parts (string match -ir "^(\s*)($sudope_command(\s+|\$))?(.*)" $command_buffer[1])
 
   # Handle multiline commands with extra care.
   set -l command_lines_count (count $command_buffer)
@@ -30,11 +30,11 @@ function sudope -d "Quickly toggle super user command prefix"
       # No su command.
 
       # Add the su command to the beginning of the command, after any leading whitespace (if present).
-      commandline -r (string join \n (string join '' $command_parts[2] "$su_command " $command_parts[3]) $command_rest)
+      commandline -r (string join \n (string join '' $command_parts[2] "$sudope_command " $command_parts[3]) $command_rest)
 
       # Push the cursor position ahead if necessary
       test $cursor_position -ge (string length -- "$command_parts[2]")
-        and set cursor_position (math $cursor_position+$su_command_length)
+        and set cursor_position (math $cursor_position+$sudope_command_length)
 
       # Place the cursor where it was (or where it should be).
       commandline -C $cursor_position
@@ -47,10 +47,10 @@ function sudope -d "Quickly toggle super user command prefix"
 
       # Push the cursor position back if appropriate (su command and whitespace).
       set -l lead_length (string length -- "$command_parts[2]")
-      set su_command_length (string length -- "$command_parts[3]")
-      if test $cursor_position -ge (math $lead_length+$su_command_length)
+      set sudope_command_length (string length -- "$command_parts[3]")
+      if test $cursor_position -ge (math $lead_length+$sudope_command_length)
         # The cursor was after the su command.
-        set cursor_position (math $cursor_position-$su_command_length)
+        set cursor_position (math $cursor_position-$sudope_command_length)
       else if test $cursor_position -ge $lead_length
         # The cursor was somewhere on the su command.
         set cursor_position $lead_length

--- a/functions/sudope.fish
+++ b/functions/sudope.fish
@@ -1,8 +1,16 @@
-function sudope -d "Quickly toggle sudo prefix"
+function sudope -d "Quickly toggle super user command prefix"
 
   # Save the current command line and cursor position.
   set -l command_buffer (commandline)
   set -l cursor_position (commandline -C)
+
+  # If no custom super user command defaults to sudo
+  if test -z "$su_command"
+    set su_command 'sudo'
+  end
+
+  # Save su command length
+  set -l su_command_length (string length -- "$su_command")
 
   # If the command line is empty, pull the last command from history.
   if test -z "$command_buffer"
@@ -10,7 +18,7 @@ function sudope -d "Quickly toggle sudo prefix"
   end
 
   # Parse the command line (first line only).
-  set -l command_parts (string match -ir '^(\s*)(sudo(\s+|$))?(.*)' $command_buffer[1])
+  set -l command_parts (string match -ir "^(\s*)($su_command(\s+|\$))?(.*)" $command_buffer[1])
 
   # Handle multiline commands with extra care.
   set -l command_lines_count (count $command_buffer)
@@ -19,32 +27,32 @@ function sudope -d "Quickly toggle sudo prefix"
 
   switch (count $command_parts)
     case 3
-      # No "sudo".
+      # No su command.
 
-      # Add "sudo" to the beginning of the command, after any leading whitespace (if present).
-      commandline -r (string join \n (string join '' $command_parts[2] 'sudo ' $command_parts[3]) $command_rest)
+      # Add the su command to the beginning of the command, after any leading whitespace (if present).
+      commandline -r (string join \n (string join '' $command_parts[2] "$su_command " $command_parts[3]) $command_rest)
 
-      # Push the cursor position ahead if necessary (+5 for 'sudo ').
+      # Push the cursor position ahead if necessary
       test $cursor_position -ge (string length -- "$command_parts[2]")
-        and set cursor_position (math $cursor_position+5)
+        and set cursor_position (math $cursor_position+$su_command_length)
 
       # Place the cursor where it was (or where it should be).
       commandline -C $cursor_position
 
     case 5
-      # "sudo" is present in the beginning of the command.
+      # The su comamnd is present in the beginning of the command.
 
-      # Remove "sudo", leave any leading whitespace (if present).
+      # Remove the su command, leave any leading whitespace (if present).
       commandline -r (string join \n (string join '' $command_parts[2 5]) $command_rest)
 
-      # Push the cursor position back if appropriate ('sudo' and whitespace).
+      # Push the cursor position back if appropriate (su command and whitespace).
       set -l lead_length (string length -- "$command_parts[2]")
-      set -l sudo_length (string length -- "$command_parts[3]")
-      if test $cursor_position -ge (math $lead_length+$sudo_length)
-        # The cursor was after "sudo".
-        set cursor_position (math $cursor_position-$sudo_length)
+      set su_command_length (string length -- "$command_parts[3]")
+      if test $cursor_position -ge (math $lead_length+$su_command_length)
+        # The cursor was after the su command.
+        set cursor_position (math $cursor_position-$su_command_length)
       else if test $cursor_position -ge $lead_length
-        # The cursor was somewhere on "sudo".
+        # The cursor was somewhere on the su command.
         set cursor_position $lead_length
       end
 

--- a/functions/sudope.fish
+++ b/functions/sudope.fish
@@ -36,7 +36,7 @@ function sudope -d "Quickly toggle super user command prefix"
 
       # Push the cursor position ahead if necessary
       test $cursor_position -ge (string length -- "$command_parts[2]")
-        and set cursor_position (math $cursor_position+$sudope_command_length)
+        and set cursor_position (math $cursor_position+$sudope_command_length+1)
 
       # Place the cursor where it was (or where it should be).
       commandline -C $cursor_position

--- a/functions/sudope.fish
+++ b/functions/sudope.fish
@@ -8,6 +8,9 @@ function sudope -d "Quickly toggle super user command prefix"
   test -n "$sudope_command"
     or set -l sudope_command 'sudo'
 
+  # Save regex escaped version of super user command for later
+  set -l sudope_command_re (string escape --style=regex "$sudope_command")
+
   # Save su command length
   set -l sudope_command_length (string length -- "$sudope_command")
 
@@ -17,7 +20,7 @@ function sudope -d "Quickly toggle super user command prefix"
   end
 
   # Parse the command line (first line only).
-  set -l command_parts (string match -ir "^(\s*)($sudope_command(\s+|\$))?(.*)" $command_buffer[1])
+  set -l command_parts (string match -ir "^(\s*)($sudope_command_re(\s+|\$))?(.*)" $command_buffer[1])
 
   # Handle multiline commands with extra care.
   set -l command_lines_count (count $command_buffer)

--- a/functions/sudope.fish
+++ b/functions/sudope.fish
@@ -5,9 +5,8 @@ function sudope -d "Quickly toggle super user command prefix"
   set -l cursor_position (commandline -C)
 
   # If no custom super user command defaults to sudo
-  if test -z "$sudope_command"
-    set sudope_command 'sudo'
-  end
+  test -n "$sudope_command"
+    or set -l sudope_command 'sudo'
 
   # Save su command length
   set -l sudope_command_length (string length -- "$sudope_command")
@@ -47,7 +46,7 @@ function sudope -d "Quickly toggle super user command prefix"
 
       # Push the cursor position back if appropriate (su command and whitespace).
       set -l lead_length (string length -- "$command_parts[2]")
-      set sudope_command_length (string length -- "$command_parts[3]")
+      set -l sudope_command_length (string length -- "$command_parts[3]")
       if test $cursor_position -ge (math $lead_length+$sudope_command_length)
         # The cursor was after the su command.
         set cursor_position (math $cursor_position-$sudope_command_length)


### PR DESCRIPTION
This PR adds and documents the possibility to set a custom super user command to prepend to the command line, such as `doas` instead of `sudo` for *BSD users.

You can set the custom su command in the variable `su_command`.